### PR TITLE
0.13.5 Bug - Fix Log Rotator

### DIFF
--- a/backend/src/Configuration.py
+++ b/backend/src/Configuration.py
@@ -30,7 +30,7 @@ class Configuration:
     # Default once a day
     "LOG_ROTATION_JOB_INTERVAL_MINUTES" : 1440,
     "LOG_ROTATION_JOB_EXPIRATION_DAYS"  : 1,
-    "LOG_ROTATION_JOB_ARCHIVE_DIR"      : f"{LogFactory.log_dir}{os.sep}archive{os.sep}",
+    "LOG_ROTATION_JOB_ARCHIVE_DIR"      : f"archive{os.sep}",
     "UI_LOGGING_JOB_INTERVAL_MINUTES" : 1,
     "UI_LOGGING_JOB_LOGS_PER_JOB"     : 50,
     "BUG_REPORT_EMAIL_LIST" : ["zrmmaster92@gmail.com", "roderickjmacleod@gmail.com"]


### PR DESCRIPTION
Log rotator is trying to rotate logs based on log dir, which it shouldn't do. 

```[2021-12-12 00:21:13,459 INFO]: Archiving logs/http.log
Process Process-4:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/local/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/src/MultiThreading/jobs/LogRotationJob.py", line 25, in log_rotation_job
    Cron.execute_jobs()
  File "/src/MultiThreading/Cron.py", line 26, in execute_jobs
    schedule.run_pending()
  File "/usr/local/lib/python3.8/site-packages/schedule/__init__.py", line 780, in run_pending
    default_scheduler.run_pending()
  File "/usr/local/lib/python3.8/site-packages/schedule/__init__.py", line 100, in run_pending
    self._run_job(job)
  File "/usr/local/lib/python3.8/site-packages/schedule/__init__.py", line 172, in _run_job
    ret = job.run()
  File "/usr/local/lib/python3.8/site-packages/schedule/__init__.py", line 661, in run
    ret = self.job_func()
  File "/src/MultiThreading/jobs/LogRotationJob.py", line 32, in rotate_logs
    LogRotationJob.rotate_daily_logs()
  File "/src/MultiThreading/jobs/LogRotationJob.py", line 46, in rotate_daily_logs
    FileIO.copy_file(fullPath, f"{CONF_INSTANCE.LOG_ROTATION_JOB_ARCHIVE_DIR}{datetime.datetime.now()}-{fullPath}")
  File "/src/util/FileIO.py", line 85, in copy_file
    shutil.copyfile(source, destintation)
  File "/usr/local/lib/python3.8/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
FileNotFoundError: [Errno 2] No such file or directory: '//logs/archive/2021-12-12 00:21:13.459638-logs/http.log'
//logs```